### PR TITLE
Update-WebrootConsoleGSMSite should only have GSMKey and SiteID as mandatory parameters. 

### DIFF
--- a/WebrootUnity/Public/Console/GSM/Site Management/Update-WebrootConsoleGSMSite.ps1
+++ b/WebrootUnity/Public/Console/GSM/Site Management/Update-WebrootConsoleGSMSite.ps1
@@ -23,8 +23,6 @@ function Update-WebrootConsoleGSMSite {
     )
 
     $url = "https://unityapi.webrootcloudav.com/service/api/console/gsm/$($GSMKey)/sites/$($SiteID)"
-
-    
     
     $Body = @{SiteName=$SiteName;
                 Seats=$Seats;

--- a/WebrootUnity/Public/Console/GSM/Site Management/Update-WebrootConsoleGSMSite.ps1
+++ b/WebrootUnity/Public/Console/GSM/Site Management/Update-WebrootConsoleGSMSite.ps1
@@ -6,11 +6,11 @@ function Update-WebrootConsoleGSMSite {
         [string]$GSMKey,
         [Parameter(Mandatory=$True)]
         [string]$SiteID,
-        [Parameter(Mandatory=$True)]
+        [Parameter(Mandatory=$False)]
         [string]$SiteName,
-        [Parameter(Mandatory=$True)]
+        [Parameter(Mandatory=$False)]
         [int]$Seats,
-        [Parameter(Mandatory=$True)]
+        [Parameter(Mandatory=$False)]
         [string]$Comments,
         [ValidateSet("Annually","Quarterly","Monthly","Weekly")]
         [string]$BillingCycle,
@@ -18,12 +18,14 @@ function Update-WebrootConsoleGSMSite {
         [switch]$GlobalPolicies,
         [switch]$GlobalOverrides,
         [string]$PolicyId,
-        [Parameter(Mandatory=$True)]
+        [Parameter(Mandatory=$False)]
         [string]$Emails
     )
 
     $url = "https://unityapi.webrootcloudav.com/service/api/console/gsm/$($GSMKey)/sites/$($SiteID)"
 
+    
+    
     $Body = @{SiteName=$SiteName;
                 Seats=$Seats;
                 Comments=$Comments;
@@ -33,6 +35,9 @@ function Update-WebrootConsoleGSMSite {
                 GlobalOverrides=$GlobalOverrides;
                 PolicyId=$PolicyId;
                 Emails=$Emails;}
+    
+    ($Body.GetEnumerator() | ? { -not $_.Value }) | % {$Body.Remove($_.Name) }
+    
     $Body = $Body | ConvertTo-Json
 
 


### PR DESCRIPTION
#3 

All parameters except for GSMKey and SiteID set to Mandatory=$false

Line 39 added to filter out null values from the $Body hashtable prior to converting to JSON