### PR TITLE
Set-WebrootConsoleGSMEndpointGroup - fixed issue with $inheritance parameter

### DIFF
--- a/WebrootUnity/Public/Console/GSM/Endpoint Management/Set-WebrootConsoleGSMEndpointGroup.ps1
+++ b/WebrootUnity/Public/Console/GSM/Endpoint Management/Set-WebrootConsoleGSMEndpointGroup.ps1
@@ -10,22 +10,18 @@ function Set-WebrootConsoleGSMEndpointGroup {
         [string]$SourceGroupId,
         [Parameter(Mandatory=$True)]
         [string]$TargetGroupId,
-        [ValidateSet("Unchanged","All","Update")]
-        [string]$Inheritance = "Unchanged"
+        [ValidateSet(0,1)]
+        [int]$Inheritance = 0
     )
 
     $url = "https://unityapi.webrootcloudav.com/service/api/console/gsm/$($GSMKey)/sites/$($SiteID)/endpoints"
 
-    switch ($Inheritance){
-        'Unchanged'{$Inheritance = 0}
-        'All'{$Inheritance = 1}
-        'Update'{$Inheritance = 3}
+    $Body = @{
+        EndpointsList = $EndpointsList
+        SourceGroupId = $SourceGroupId
+        TargetGroupId = $TargetGroupId
+        Inheritance   = $Inheritance
     }
-
-    $Body = @{EndpointsList=$EndpointsList;
-                SourceGroupId=$SourceGroupId;
-                TargetGroupId=$TargetGroupId;
-                Inheritance=$Inheritance;}
     $Body = $Body | ConvertTo-Json
 
     if ($PSCmdlet.ShouldProcess($WebRequestArguments.URI, "Invoke-RestMethod, with body:`r`n$Body`r`n")) {
@@ -36,7 +32,7 @@ function Set-WebrootConsoleGSMEndpointGroup {
             Invoke-RestMethod -Method Put -Uri $url -ContentType "application/json" -Body $Body -Headers @{"Authorization" = "Bearer $($WebrootAuthToken.access_token)"}
         }
         catch{
-            Write-Error "Error: $($Error[0])"
+            Write-Error "Error: $_.Exception.Message"
         }
     }
 }


### PR DESCRIPTION
Found an issue with the 'Inheritance' parameter. It was failing to evaluate from the switch statement. I removed the switch statement all together and cast the parameter to an integer (validating 0 or 1).

3 or 'Update' is no longer supported (reference here: https://unityapi.webrootcloudav.com/Docs/en/APIDoc/Api/PUT-api-console-gsm-gsmKey-sites-siteId-endpoints)

Also, Write-Error "Error: $($Error[0])" was returning nothing. I changed that to $_.Exception.Message to get something back.